### PR TITLE
Update thirdParty_motion.cpp

### DIFF
--- a/C++/thirdParty_motion.cpp
+++ b/C++/thirdParty_motion.cpp
@@ -81,7 +81,7 @@ Trackable::Trackable(vector<unsigned char> *data, uint16_t intSig, uint16_t fltS
 	data->erase(data->begin(), data->begin() + 1);
 
 	this->name.append(data->begin(), data->begin() + this->nameLen);
-	data->erase(data->begin(), data->begin() + sizeof(unsigned char)*this->nameLen);
+	data->erase(data->begin(), data->begin() + this->nameLen);
 
 	if (this->pkType == 0x51)
 	{


### PR DESCRIPTION
BTXLOK-460 Trackable module was that initialising name erasing more data from the vector than necessary
http://jira:8080/browse/BTXLOK-460