### PR TITLE
Replace winsock2 with cmath

### DIFF
--- a/C++/protocol_common.h
+++ b/C++/protocol_common.h
@@ -8,6 +8,6 @@
 #include <vector>
 #include <inttypes.h>
 #include <stdlib.h>
-#include <winsock2.h>
+#include <cmath>
 
 #endif // PROTOCOL_COMMON_H


### PR DESCRIPTION
In a macOS environment, `winsock2` isn't available. The only lines of code that used `winsock2` were in thirdParty_motion.cpp (lines: 384, 389, 394, 400, 404, 408) specifically using `M_PI`. Simply adding #include<cmath> fixes that.